### PR TITLE
allow common parameters to be overwritten by custom ones

### DIFF
--- a/lib/expedia/http_service.rb
+++ b/lib/expedia/http_service.rb
@@ -37,7 +37,7 @@ module Expedia
       # @return [Expedia::HTTPService::Response] on success. A response object representing the results from Expedia
       # @return [Expedia::APIError] on Error.
       def make_request(path, args, verb, options = {})
-        args.merge!(add_common_parameters)
+        args = common_parameters.merge(args)
         # figure out our options for this request
         request_options = {:params => (verb == :get ? args : {})}
         # set up our Faraday connection
@@ -86,7 +86,7 @@ module Expedia
 
       # Common Parameters required for every Call to Expedia Server.
       #
-      def add_common_parameters
+      def common_parameters
         { :cid => Expedia.cid, :sig => signature, :apiKey => Expedia.api_key, :minorRev => Expedia.minor_rev,
           :_type => 'json', :locale => Expedia.locale, :currencyCode => Expedia.currency_code }
       end

--- a/spec/http_service_spec.rb
+++ b/spec/http_service_spec.rb
@@ -30,7 +30,7 @@ describe "Expedia::HTTPService" do
 
   end
 
-  describe "signature and add_common_parameters" do
+  describe "signature and common_parameters" do
 
     before :each do
       Expedia.cid = ''
@@ -46,10 +46,10 @@ describe "Expedia::HTTPService" do
     end
 
     it "returns a hash containing common params" do
-      Expedia::HTTPService.add_common_parameters.keys.should include(:cid)
-      Expedia::HTTPService.add_common_parameters.keys.should include(:apiKey)
-      Expedia::HTTPService.add_common_parameters.keys.should include(:sig)
-      Expedia::HTTPService.add_common_parameters.keys.should include(:_type)
+      Expedia::HTTPService.common_parameters.keys.should include(:cid)
+      Expedia::HTTPService.common_parameters.keys.should include(:apiKey)
+      Expedia::HTTPService.common_parameters.keys.should include(:sig)
+      Expedia::HTTPService.common_parameters.keys.should include(:_type)
     end
   end
 


### PR DESCRIPTION
Allow parameter overwrite for expedia requests, like setting a different currency_code or locale. 
