### PR TITLE
Up the colorize dependency version

### DIFF
--- a/expedia.gemspec
+++ b/expedia.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency(%q<multi_json>,    ["~> 1.3"])
   gem.add_runtime_dependency(%q<faraday>,       ["~> 0.8"])
-  gem.add_runtime_dependency(%q<colorize>,      ["~> 0.5.8"])
+  gem.add_runtime_dependency(%q<colorize>,      ["~> 0.7"])
   gem.add_runtime_dependency(%q<addressable>,   ["~> 2.2"])
   gem.add_development_dependency(%q<rspec>,     ["~> 2.8"])
   gem.add_development_dependency(%q<rake>,      ["~> 0.8"])


### PR DESCRIPTION
I ran into an issue with the sshkit gem having the same dependency on colorize. Only it would call options that don't exist yet in version 0.5.8, but do exist in the latest 0.7.x release.

The error: `undefined method 'bold' for Color:Module`

I updated the colorize gem in the expedia gem, ran the specs on ruby `2.1.2`, `2.0.0-p451` and had no failures.
Anything else I can do to make sure this gets merged?
