### PR TITLE
Allow `cid` to be a string

### DIFF
--- a/lib/expedia/http_service.rb
+++ b/lib/expedia/http_service.rb
@@ -19,7 +19,7 @@ module Expedia
       #
       # @return a complete server address with protocol
       def server(options = {})
-        if Expedia.cid == 55505
+        if Expedia.cid.to_i == 55505
           server = DEVELOPMENT_SERVER
         else
           server = options[:reservation_api] ? RESERVATION_SERVER : API_SERVER

--- a/spec/http_service_spec.rb
+++ b/spec/http_service_spec.rb
@@ -35,6 +35,9 @@ describe "Expedia::HTTPService" do
     it "return DEVELOPMENT_SERVER server when cid is 55505" do
       Expedia.stub(:cid).and_return(55505)
       Expedia::HTTPService.server.should =~ Regexp.new(Expedia::HTTPService::DEVELOPMENT_SERVER)
+
+      Expedia.stub(:cid).and_return("55505")
+      Expedia::HTTPService.server.should =~ Regexp.new(Expedia::HTTPService::DEVELOPMENT_SERVER)
     end
 
   end


### PR DESCRIPTION
I was loading the configuration for `Expedia.cid` directly from a `Rails.configuration` value like this:

``` ruby
Expedia.cid = Rails.configuration.expedia_cid
```

When doing this, the value supplied will always be a String. This was causing authentication to fail with Expedia as the production server was being used instead of the development server. I think this is a very common use case. This commit fixes potential head scratching.
