### PR TITLE
Updated condition for request method type for get_list

### DIFF
--- a/lib/expedia/api.rb
+++ b/lib/expedia/api.rb
@@ -6,11 +6,9 @@ module Expedia
     # @param args [Hash] All the params required for 'get_list' call
     # @return [Expedia::HTTPService::Response] on success. A response object representing the results from Expedia
     # @return [Expedia::APIError] on Error.
-    # @note A POST request is made instead of GET if 'numberOfResults' > 200
+    # @note A POST request is made instead of GET if 'hotelIdList' length > 200
     def get_list(args)
-      no_of_results = 'numberOfResults'
-      method = (args[no_of_results.to_sym].to_i > 200 || args[no_of_results].to_i > 200) ||
-        args[no_of_results.downcase.to_sym].to_i > 200 || args[no_of_results.downcase].to_i > 200 ? :post : :get
+      method = (args[:hotelIdList] || args["hotelIdList"] || []).length > 200 ? :post : :get
       services('/ean-services/rs/hotel/v3/list', args, method)
     end
 


### PR DESCRIPTION
I ran into an issue when using the `get_list` method including a large `hotelIdList`. I noticed that the check for doing a post or get request was done based on possible response size instead of request size.

I updated the method to check for `hotelIdList` length > 200 instead of `numberOfResults`, because the GET/POST request is not determined on the `numberOfResults` parameter, but the `hotelIdList` parameter.
The `numberOfResults` has no impact on it, besides the only acceptable values are 0 < val < 200, according to expedia API documentation.

> Maximum number of hotels to return. Acceptable value range is 1 to 200. Default: 20 

[Source](http://dev.ean.com/docs/hotel-list/#numberOfResults)

Instead a POST request should be made if a 'long' `hotelIdList` is provided.

> When using long lists, be aware that response times may increase noticably vs. smaller lists across multiple requests. Use POST instead of GET when sending long lists via REST.

[Source](http://dev.ean.com/docs/hotel-list/#hotelIdList)

The boundaries for length of a long list are not specified in the documentation. So I set it on 200 for now. I noticed it is currently on 500, but lets keep some headroom for unforeseen expedia API changes.

I saw no specs for the Api class, so couldn't update any. I would recommend some specs, but have not enough experience to set this up.

Let me know if there's anything else I can do/answer any questions.