### PR TITLE
Request Timeout

### DIFF
--- a/lib/expedia.rb
+++ b/lib/expedia.rb
@@ -23,7 +23,7 @@ module Expedia
   class << self
 
     attr_accessor :cid, :api_key, :shared_secret, :format, :locale,
-      :currency_code, :minor_rev
+      :currency_code, :minor_rev, :timeout, :open_timeout
 
     # Default way to setup Expedia. Run generator to create
     # a fresh initializer with all configuration values.

--- a/lib/expedia/api.rb
+++ b/lib/expedia/api.rb
@@ -43,7 +43,7 @@ module Expedia
     end
 
     def get_reservation(args)
-      HTTPService.make_request('/ean-services/rs/hotel/v3/res', args, :post, { :reservation_api => true, :use_ssl => true })
+      HTTPService.make_request('/ean-services/rs/hotel/v3/res', args, :post, { :reservation_api => true, :use_ssl => true, :ignore_timeout => true })
     end
 
     def get_payment_info(args)

--- a/lib/expedia/http_service.rb
+++ b/lib/expedia/http_service.rb
@@ -27,6 +27,20 @@ module Expedia
         "#{options[:use_ssl] ? "https" : "http"}://#{server}"
       end
 
+
+      # Adding open and read timeouts
+      #
+      # open timeout - the amount of time you are willing to wait for 'opening a connection'
+      # (read) timeout - the amount of time you are willing to wait for some data to be received from the connected party.
+      # @param conn - Faraday connection object
+      #
+      # @return the connection obj with the timeouts set if they have been initialized
+      def add_timeouts(conn)
+        conn.options.timeout = Expedia.timeout.to_i if Expedia.timeout.present?
+        conn.options.open_timeout = Expedia.open_timeout.to_i if Expedia.open_timeout.present?
+        conn
+      end
+
       # Makes a request directly to Expedia.
       # @note You'll rarely need to call this method directly.
       #
@@ -47,6 +61,7 @@ module Expedia
         request_options = {:params => (verb == :get ? args : {})}
         # set up our Faraday connection
         conn = Faraday.new(server(options), request_options)
+        conn = HTTPService.add_timeouts(conn)
         response = conn.send(verb, path, (verb == :post ? args : {}))
 
         # Log URL and params information

--- a/lib/expedia/http_service.rb
+++ b/lib/expedia/http_service.rb
@@ -35,9 +35,11 @@ module Expedia
       # @param conn - Faraday connection object
       #
       # @return the connection obj with the timeouts set if they have been initialized
-      def add_timeouts(conn)
-        conn.options.timeout = Expedia.timeout.to_i if Expedia.timeout.present?
-        conn.options.open_timeout = Expedia.open_timeout.to_i if Expedia.open_timeout.present?
+      def add_timeouts(conn, options)
+        if !options[:ignore_timeout]
+          conn.options.timeout = Expedia.timeout.to_i if Expedia.timeout.present?
+          conn.options.open_timeout = Expedia.open_timeout.to_i if Expedia.open_timeout.present?
+        end
         conn
       end
 
@@ -61,7 +63,7 @@ module Expedia
         request_options = {:params => (verb == :get ? args : {})}
         # set up our Faraday connection
         conn = Faraday.new(server(options), request_options)
-        conn = HTTPService.add_timeouts(conn)
+        conn = HTTPService.add_timeouts(conn, options)
         response = conn.send(verb, path, (verb == :post ? args : {}))
 
         # Log URL and params information


### PR DESCRIPTION
We are working with Expedia API and sometimes we encountered service outage which causes slow clients.
In order to catch them we implemented a timeout option. In our experience connection timeouts of minimum ~0.13 seconds and bandwidth timeouts of minimum ~2.2 seconds.
The timeout is ignoring the booking action since the it might take longer then the other requests.