### PR TITLE
Ran into an issue when I was using ip whitelisting.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -37,6 +37,7 @@ Expedia.shared_secret = 'your_shared_secret'
 Expedia.locale = 'en_US'
 Expedia.currency_code = 'USD'
 Expedia.minor_rev = 13
+Expedia.use_signature = true # must be false if using ip whitelisting instead of signature
 # Optional configuration...
 Expedia.timeout = 1 # read timeout in sec
 Expedia.open_timeout = 1 # connection timeout in sec

--- a/lib/expedia.rb
+++ b/lib/expedia.rb
@@ -23,11 +23,12 @@ module Expedia
   class << self
 
     attr_accessor :cid, :api_key, :shared_secret, :format, :locale,
-      :currency_code, :minor_rev, :timeout, :open_timeout
+      :currency_code, :minor_rev, :timeout, :open_timeout, :use_signature
 
     # Default way to setup Expedia. Run generator to create
     # a fresh initializer with all configuration values.
     def setup
+      Expedia.use_signature = true #default
       yield self
     end
 

--- a/lib/expedia/http_service.rb
+++ b/lib/expedia/http_service.rb
@@ -93,8 +93,9 @@ module Expedia
       # Common Parameters required for every Call to Expedia Server.
       # @return [Hash] of all common parameters.
       def common_parameters
-        { :cid => Expedia.cid, :sig => signature, :apiKey => Expedia.api_key, :minorRev => Expedia.minor_rev,
-          :_type => 'json', :locale => Expedia.locale, :currencyCode => Expedia.currency_code }
+        params = { :cid => Expedia.cid, :apiKey => Expedia.api_key, :minorRev => Expedia.minor_rev, :_type => 'json', :locale => Expedia.locale, :currencyCode => Expedia.currency_code }
+        params.merge!(:sig => signature) if Expedia.use_signature
+        return params
       end
 
     end

--- a/lib/expedia/version.rb
+++ b/lib/expedia/version.rb
@@ -1,3 +1,3 @@
 module Expedia
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end

--- a/lib/generators/templates/expedia.txt
+++ b/lib/generators/templates/expedia.txt
@@ -5,6 +5,7 @@ Expedia.setup do |config|
   config.locale = 'en_US' # For Example 'de_DE'. Default is 'en_US'
   config.currency_code = 'USD' # For Example 'EUR'. Default is 'USD'
   config.minor_rev = 28 # between 4-28 as of Jan 2015. If not set, 4 is used by EAN.
+  config.use_signature = true # An encoded signature is not required if ip whitelisting is used
   # optional configurations...
   config.timeout = 1 # read timeout in sec
   config.open_timeout = 1 # connection timeout in sec

--- a/spec/http_service_spec.rb
+++ b/spec/http_service_spec.rb
@@ -48,6 +48,7 @@ describe "Expedia::HTTPService" do
       Expedia.cid = ''
       Expedia.api_key =''
       Expedia.shared_secret = ''
+      Expedia.use_signature = true
 
     end
 
@@ -62,6 +63,11 @@ describe "Expedia::HTTPService" do
       Expedia::HTTPService.common_parameters.keys.should include(:apiKey)
       Expedia::HTTPService.common_parameters.keys.should include(:sig)
       Expedia::HTTPService.common_parameters.keys.should include(:_type)
+    end
+    
+    it "checks to see if sig is removed from parameters" do
+      Expedia.use_signature = false
+      Expedia::HTTPService.common_parameters.keys.should_not include(:sig)
     end
   end
 


### PR DESCRIPTION
Ran into an issue where the signature wasn't required since I used IP whitelisting. Talked with a tech at expedia and they mentioned a change on their end that if a signature is provided the ip whitelisting is ignored. This change will allow users to disable passing along the signature.
