### PR TITLE
Feature/modify end point

### DIFF
--- a/lib/expedia/http_service.rb
+++ b/lib/expedia/http_service.rb
@@ -4,7 +4,7 @@ require 'expedia/http_service/response'
 module Expedia
   module HTTPService
 
-    API_SERVER = 'api.eancdn.com'
+    API_SERVER = 'api.ean.com'
     # The development api server is not reliable. Often gives 400...
     # DEVELOPMENT_API_SERVER = 'dev.api.ean.com'
     DEVELOPMENT_API_SERVER = 'api.ean.com'

--- a/lib/expedia/http_service.rb
+++ b/lib/expedia/http_service.rb
@@ -5,9 +5,6 @@ module Expedia
   module HTTPService
 
     API_SERVER = 'api.ean.com'
-    # The development api server is not reliable. Often gives 400...
-    # DEVELOPMENT_API_SERVER = 'dev.api.ean.com'
-    DEVELOPMENT_API_SERVER = 'api.ean.com'
     RESERVATION_SERVER = 'book.api.ean.com'
 
     class << self
@@ -21,11 +18,7 @@ module Expedia
       #
       # @return a complete server address with protocol
       def server(options = {})
-        if Expedia.cid.to_i == 55505 && !options[:reservation_api]
-          server = DEVELOPMENT_API_SERVER
-        else
-          server = options[:reservation_api] ? RESERVATION_SERVER : API_SERVER
-        end
+        server = options[:reservation_api] ? RESERVATION_SERVER : API_SERVER
         "#{options[:use_ssl] ? "https" : "http"}://#{server}"
       end
 

--- a/spec/http_service_spec.rb
+++ b/spec/http_service_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 describe "Expedia::HTTPService" do
 
-  it "has an DEVELOPMENT_API_SERVER Constant" do
-    Expedia::HTTPService.constants.should include(:DEVELOPMENT_API_SERVER)
-  end
-
   it "has an API_SERVER Constant" do
     Expedia::HTTPService.constants.should include(:API_SERVER)
   end
@@ -32,14 +28,6 @@ describe "Expedia::HTTPService" do
       Expedia::HTTPService.server( {:use_ssl => true }).should eql "https://#{Expedia::HTTPService::API_SERVER}"
     end
 
-    it "return DEVELOPMENT_API_SERVER server when cid is 55505" do
-      Expedia.stub(:cid).and_return(55505)
-      Expedia::HTTPService.server.should =~ Regexp.new(Expedia::HTTPService::DEVELOPMENT_API_SERVER)
-
-      Expedia.stub(:cid).and_return("55505")
-      Expedia::HTTPService.server.should =~ Regexp.new(Expedia::HTTPService::DEVELOPMENT_API_SERVER)
-    end
-
   end
 
   describe "signature and common_parameters" do
@@ -64,7 +52,7 @@ describe "Expedia::HTTPService" do
       Expedia::HTTPService.common_parameters.keys.should include(:sig)
       Expedia::HTTPService.common_parameters.keys.should include(:_type)
     end
-    
+
     it "checks to see if sig is removed from parameters" do
       Expedia.use_signature = false
       Expedia::HTTPService.common_parameters.keys.should_not include(:sig)


### PR DESCRIPTION
Change api endpoint because EAN team said `api.ean.com` already released and `api.eancdn.com` will close soon.